### PR TITLE
updating dependencies and tgstation PRs #48122, #48241, #48673

### DIFF
--- a/.github/workflows/autobuild_tgui.yml
+++ b/.github/workflows/autobuild_tgui.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+        with:
+          fetch-depth: 25
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -26,8 +28,9 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "TGUI"
+          git pull origin master
           git commit -m "Automatic TGUI Rebuild [ci skip]" -a || true
       - name: Push Artifacts
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_MASTER_KEY }}

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -17,10 +17,10 @@ export RUST_G_VERSION=0.4.2
 export BSQL_VERSION=v1.4.0.0
 
 #node version
-export NODE_VERSION=8
+export NODE_VERSION=12
 
 # PHP version
 export PHP_VERSION=5.6
 
 # SpacemanDMM git tag
-export SPACEMAN_DMM_VERSION=suite-1.0
+export SPACEMAN_DMM_VERSION=suite-1.2


### PR DESCRIPTION
## About The Pull Request
You forgot to bump up the node version to 12 when porting TGUI-next. Also bringing the autobuild up to date with tgstation.

## Why It's Good For The Game
Linter should be good now.
